### PR TITLE
Brokers: add ActiveMQ to the list of brokers supporting MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ MQTT is a lightweight client-server publish/subscribe messaging protocol, optimi
 
 ### Broker
 
+* [ActiveMQ] (http://activemq.apache.org/) - A fast Java multiprotocol messaging and Integration Patterns server.
 * [eMQTT](http://emqtt.io/) - The Massively Scalable MQTT Broker written in Erlang/OTP.
 * [hbmqtt](https://github.com/beerfactory/hbmqtt) - Python MQTT broker using asyncio.
 * [HiveMQ](http://www.hivemq.com/) - Java based commercial MQTT Broker.


### PR DESCRIPTION
While it supports other messaging protocols it's supported MQTT since 5.6.0,
added WebSockets support in 5.9.0 and improved MQTT it further in 5.10.0

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>