### PR TITLE
Add mqtt-unifi-protect-bridge by terafin to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Here are complete firmwares to turn them into MQTT-controlled smart home nodes:
 * [knx2mqtt](https://github.com/owagner/knx2mqtt) - Interface between the KNX home automation standard and MQTT.
 * [mcsMQTT](https://shop.homeseer.com/products/mcsmqtt-software-plug-in-for-hs3) - Plug-in for HS3 (HomeSeer).
 * [mqtt-dss-bridge](https://github.com/cgHome/mqtt-dss-bridge) - MQTT digitalSTROM-Server Bridge.
+* [mqtt-unifi-protect-bridge](https://github.com/terafin/mqtt-unifi-protect-bridge) - Adding motion-status from UniFi Protect Cameras to MQTT.
 * [mqtt2homekit](https://github.com/forty2/mqtt2homekit) - Roughly the opposite of [homekit2mqtt](https://github.com/hobbyquaker/homekit2mqtt): Control your HomeKit-enabled devices with MQTT and without Siri or iPhone.
 * [node-lox-mqtt-gateway](https://github.com/alladdin/node-lox-mqtt-gateway) - Gateway for Loxone™ mini server to communicate with MQTT broker.
 * [smartthings-mqtt-bridge](https://github.com/stjohnjohnson/smartthings-mqtt-bridge) - Bridge between [SmartThings](https://www.smartthings.com/) and MQTT.


### PR DESCRIPTION
This commit adds [mqtt-unifi-protect-bridge](https://github.com/terafin/mqtt-unifi-protect-bridge) to the list.
mqtt-unifi-protect-bridge is a docker container for transmitting the motion-alert-status of UniFi Protect Cameras to MQTT for further automation.