### PR TITLE
Add mqtt5 to Brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [Moquette](https://github.com/moquette-io/moquette) - Java MQTT lightweight broker.
 - [Mosca](https://www.mosca.io/) - Node.js MQTT broker, which can be used Standalone or Embedded in another Node.js application.
 - [Mosquitto](https://mosquitto.org/) - *"*The"** Open Source MQTT Broker.
+- [mqtt5](https://github.com/LabOverWire/mqtt-lib) - Async MQTT v5.0 broker in Rust with TCP, TLS, WebSocket, and QUIC transport, plus authentication, ACL, bridging, and session persistence.
 - [MyQttHub](https://myqtthub.com) - Cloud MQTT broker.
 - [Mystique](https://github.com/TheThingsIndustries/mystique) - An extendable MQTT broker written in Go, with HTTP capabilities for observability. Implements MQTT v3.1.1.
 - [RabbitMQ](https://www.rabbitmq.com/mqtt.html) - High performance messaging broker with MQTT Adapter.


### PR DESCRIPTION
mqtt5 is an async MQTT v5.0 broker written in Rust. It supports TCP, TLS, WebSocket, and QUIC transports, with authentication, ACL, bridging, and session persistence. Sorted alphabetically after Mosquitto.

https://github.com/LabOverWire/mqtt-lib