### PR TITLE
Add mqtt5 to Rust Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 
 - [mqtt-rs](https://github.com/zonyitoo/mqtt-rs) - MQTT protocol library for Rust.
 - [rumqtt](https://github.com/AtherEnergy/rumqtt) - A fast, lock free pure Rust MQTT client.
+- [mqtt5](https://github.com/LabOverWire/mqtt-lib) - Complete async MQTT v5.0 client and broker library for Rust with TCP, TLS, WebSocket, and QUIC support.
 
 ### Swift
 


### PR DESCRIPTION
mqtt5 is a complete async MQTT v5.0 client and broker library for Rust with TCP, TLS, WebSocket, and QUIC support. Sorted alphabetically after rumqtt.

https://github.com/LabOverWire/mqtt-lib