### PR TITLE
Add mqttv5 CLI to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [mqtt-stats](https://github.com/gambitcomminc/mqtt-stats) - Subscriber client to monitor MQTT Topic Statistics.
 - [mqtt_monitor](https://github.com/filipsPL/mqtt-monitor) - Simple and lightweight console moniotor for mqtt topics, with eye-candies, in python 3.
 - [mqttcommander](https://github.com/vroomfondel/mqttcommander) - A console-based MQTT client and commander, especially useful for IoT, Tasmota, and Node-RED setups.
+- [mqttv5](https://github.com/LabOverWire/mqtt-lib) - Unified MQTT v5.0 CLI for publishing, subscribing, running a broker, and benchmarking with multi-transport support.
 
 ## Clients
 


### PR DESCRIPTION
mqttv5 is a unified MQTT v5.0 CLI for publishing, subscribing, running a broker, and benchmarking over TCP, TLS, WebSocket, and QUIC. Sorted alphabetically after mqttcommander.

https://github.com/LabOverWire/mqtt-lib