### PR TITLE
Add homie-home-assistant-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 
 ## Tools
 - [hivemq-mqtt-web-client](https://github.com/hivemq/hivemq-mqtt-web-client) - Browser-based MQTT client that utilizes MQTT over websockets. [Direct Link](https://www.hivemq.com/demos/websocket-client/)
+- [homie-home-assistant-discovery](https://github.com/labodj/homie-home-assistant-discovery) - Node.js CLI and library that maps Homie MQTT metadata to Home Assistant MQTT discovery payloads.
 - [imqtt](https://github.com/shafreeck/imqtt) - Interactive MQTT packet manipulation shell based on IPython.
 - [IoT-Testware](https://projects.eclipse.org/projects/technology.iottestware) - The Eclipse IoT-Testware is a collection of conformance test suites for IoT protocols enriched with additional tools for fuzzing and performance testing.
 - [LabOverWire](https://laboverwire.com/features) - Visual diagram editor for designing MQTT topologies, built with Rust (WASM) and TypeScript. Features live in-browser simulation, code generation, and AsyncAPI export.


### PR DESCRIPTION
Hi,

thanks for maintaining this list.

This PR adds `homie-home-assistant-discovery` to the Tools section.

It is a small Node.js CLI/library that listens to Homie MQTT metadata and publishes Home Assistant MQTT discovery payloads. The intent is to bridge two existing MQTT conventions rather than define a new one: Homie already describes devices on MQTT, and Home Assistant already supports MQTT discovery.

I placed it under Tools because it is not tied to a specific broker or to the rest of my Labo Smart Home stack. It can be used as a standalone helper for Homie MQTT devices.

It currently supports Homie v3.0.1, v4 retained metadata topics, and Homie v5 `$description` documents.

Happy to adjust the wording or move it to another section if you think it fits better elsewhere.
