### PR TITLE
Add ccusage-mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Here are complete firmwares to turn them into MQTT-controlled smart home nodes:
 
 - [mqttwarn](https://mqttwarn.readthedocs.io/en/latest/) - Route and transform MQTT notifications, with 70+ built-in adapters for databases, messaging and other notification sinks.
 - [snmp2mqtt](https://c0d3.sh/andre/snmp2mqtt) - Python based SNMP v2 and v3 bridge to MQTT, active project in late 2025.
+- [ccusage-mqtt](https://github.com/george-vice/ccusage-mqtt) - Publishes Claude Code (Anthropic's AI coding agent) usage telemetry to MQTT with Home Assistant auto-discovery. 15 sensors, mood classifier.
 - [check-mqtt](https://github.com/jpmens/check-mqtt) - A Nagios/Icinga plugin for checking connectivity to an MQTT broker.
 - [nag2mqtt](https://github.com/DE-IBH/nag2mqtt) - Nagios event broker to MQTT gateway.
 - [notify-by-mqtt](https://github.com/jpmens/notify-by-mqtt) - A Nagios/Icinga notification module which wraps data into JSON and fires it off to an MQTT broker.


### PR DESCRIPTION
[ccusage-mqtt](https://github.com/george-vice/ccusage-mqtt) publishes Claude Code (Anthropic's coding agent) usage to MQTT, with Home Assistant auto-discovery. Single Python process, paho-mqtt v2, 15 sensors per device, retained payloads + LWT. Supports both Pro/Max and Enterprise plans. MIT licensed.

Landing: https://george-vice.github.io/ccusage-mqtt/

Placed under Monitoring alphabetically. Happy to move it.