### PR TITLE
Update ForestHub entry: add repo link + refresh description

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [Iotellect](https://iotellect.com/) - Low-code IoT/IIoT platform for industrial automation, SCADA, BMS and remote monitoring. Supports MQTT, OPC-UA, Modbus and 100+ protocols with visual development tools and edge-cloud integration.
 - [mainflux](https://www.mainflux.com/) - Device management, data aggregation, data management, data analytics,connectivity and message routing and event management. Supported by Linux Software Foundation.
 - [thingsboard](https://thingsboard.io/) - Device management, data collection, processing, event management, and visualization for your IoT projects.
-- [ForestHub.ai](https://foresthub.ai) - Platform for building, deploying and orchestrating embedded and edge AI agents over MQTT. Visual builder, local runtime, generated embedded code for ESP32/STM32, hybrid edge-cloud orchestration.
+- [ForestHub](https://foresthub.ai) - Edge AI agent platform; its open-source runtime [edge-agents](https://github.com/ForestHubAI/edge-agents) orchestrates AI agents on Linux edge gateways with MQTT as a first-class workflow transport, running offline with local SLMs alongside cloud LLMs.
 
 
 ## Tools


### PR DESCRIPTION
Updates the existing ForestHub entry in *Platforms*. Adds the open-source repository link ([ForestHubAI/edge-agents](https://github.com/ForestHubAI/edge-agents)) and refreshes the description — the previous text mentioned "generated embedded code for ESP32/STM32", which no longer reflects the project. Keeps the MQTT focus and the same section/format.