### PR TITLE
Add mqttkit to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [MQTT.fx](https://mqttfx.jensd.de/) - MQTT Client written in Java based on Eclipse Paho. Supports scripting.
 - [mqttcli](https://github.com/shirou/mqttcli) - MQTT Client for shell scripting.
 - [MQTTInspector](https://github.com/ckrey/MQTTInspector) - A general MQTT testing app for iOS (iPhone and iPad).
+- [mqttkit](https://github.com/keyp-dev/mqttkit) - Elysia-style application framework for MQTT on Bun and TypeScript. Compose broker adapters, ordered middleware, typed topic routes, MQTT 5 RPC, and AsyncAPI 3.0 docs with `new MqttApp().use(...)`.
 - [MQTTLens](https://chrome.google.com/webstore/detail/mqttlens/hemojaaeigabkbcookmlgmdigohjobjm) - A Google Chrome application, which connects to a MQTT broker and is able to subscribe and publish to MQTT topics.
 - [MQTT Explorer](https://mqtt-explorer.com/) - Tool to visualize your MQTT topics in a topic hierarchy, a MQTT swiss-army knife.
 - [MQTT TUI](https://github.com/EdJoPaTo/mqttui) - Simple lightweight terminal based MQTT monitor and publisher.


### PR DESCRIPTION
Adds [mqttkit](https://github.com/keyp-dev/mqttkit) — an Elysia-style application framework for MQTT on Bun and TypeScript. It plugs into Aedes (or any MQTT broker via a small adapter interface) and adds an application layer: ordered middleware, typed topic routes with topic params, Standard Schema (zod / valibot / arktype) payload validation, MQTT 5 RPC (`app.request()` / `ctx.reply()` with retries), per-route timeout / concurrency guards, structured metrics for Prometheus / OpenTelemetry, and AsyncAPI 3.0 doc generation.

- Repo: <https://github.com/keyp-dev/mqttkit>
- Docs: <https://mqttkit.keyp.dev>
- npm: [@mqttkit/core](https://www.npmjs.com/package/@mqttkit/core), [@mqttkit/aedes](https://www.npmjs.com/package/@mqttkit/aedes), [@mqttkit/asyncapi](https://www.npmjs.com/package/@mqttkit/asyncapi)
- License: MIT

Inserted under `## Tools`. Happy to move it if you'd rather have a dedicated "Frameworks" sub-section.