### PR TITLE
Add IoT DC3 to Platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [mainflux](https://www.mainflux.com/) - Device management, data aggregation, data management, data analytics,connectivity and message routing and event management. Supported by Linux Software Foundation.
 - [thingsboard](https://thingsboard.io/) - Device management, data collection, processing, event management, and visualization for your IoT projects.
 - [ForestHub](https://foresthub.ai) - Edge AI agent platform; its open-source runtime [edge-agents](https://github.com/ForestHubAI/edge-agents) orchestrates AI agents on Linux edge gateways with MQTT as a first-class workflow transport, running offline with local SLMs alongside cloud LLMs.
+- [IoT DC3](https://github.com/pnoker/iot-dc3) - Fully open-source, distributed industrial IoT platform built on Spring Cloud, with 28 built-in protocol drivers (including MQTT), AI-powered operations via Spring AI, and microservice architecture. ([Docs](https://docs.dc3.site))
 
 
 ## Tools


### PR DESCRIPTION
[IoT DC3](https://github.com/pnoker/iot-dc3) is a fully open-source, distributed industrial IoT platform built on Spring Cloud with MQTT support, 28 built-in protocol drivers, and AI-powered operations via Spring AI.

Documentation: https://docs.dc3.site